### PR TITLE
Update peerDependencies to accept React 15.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "babel-cli": "^6.6.5",
     "babel-preset-react": "^6.3.13",
-    "react": "^0.14.7"
+    "react": "^0.14.7 || ^15.0.0"
   }
 }

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+git pull
+npm version patch
+PACKAGE=$(npm pack)
+echo PACKAGE: $PACKAGE
+curl -F package=@$PACKAGE https://C__hqNZ_HngaWmEnB-ps@push.fury.io/massdrop/
+rm $PACKAGE
+git push


### PR DESCRIPTION
I believe that the package name needs to start with `babel-preset` so not renaming with the `massdrop@` prefix.
